### PR TITLE
Don't rename files in the ZIP package

### DIFF
--- a/support.js
+++ b/support.js
@@ -96,8 +96,7 @@ const createZipFile = async function(name, files) {
   });
   archive.pipe(output);
   files.map( (file) => {
-    const filename = normalizeFileName(file.filename.value);
-    archive.file(fileUrlToPath(file.file.value, DATA_FOLDER), {name: filename});
+    archive.file(fileUrlToPath(file.file.value, DATA_FOLDER));
   });
   await archive.finalize();
   return pathToFileUrl(filename, TARGET_FOLDER);


### PR DESCRIPTION
Files in the ZIP package must keep the same name to make them transferable between application stacks